### PR TITLE
Converted plugin API to use buffers instead of strings for the file contents

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "previewed",
-    "version": "1.0.0",
+    "version": "1.1.0-alpha.1",
     "description": "",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,14 +3,14 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 export type Plugin = (
-    file: string,
+    file: Buffer,
     filePath: string,
     options: {
         host: string;
         port: number;
         dir: string;
     }
-) => string;
+) => Buffer;
 
 export default function init({
     dir,
@@ -27,9 +27,7 @@ export default function init({
     app.get('/**', async (req, res) => {
         try {
             const filePath = path.join(dir, req.url);
-            const file = await fs
-                .readFile(filePath)
-                .then((buffer) => buffer.toString());
+            const file = await fs.readFile(filePath);
             const processedFiles = plugins.reduce((file, plugin) => {
                 return plugin(file, filePath, { host, port, dir });
             }, file);

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@previewed/plugin-css",
-    "version": "1.0.0",
+    "version": "1.1.0-alpha.1",
     "description": "",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -10,7 +10,7 @@ export default function css(css: string, { filetypes = ['html'] } = {}) {
         const style = jsdom.window.document.createElement('style');
         style.innerHTML = css;
         jsdom.window.document.head.appendChild(style);
-        return jsdom.serialize();
+        return Buffer.from(jsdom.serialize());
     };
     return plugin;
 }

--- a/packages/markdown-it/package.json
+++ b/packages/markdown-it/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@previewed/plugin-markdown-it",
-    "version": "1.0.0",
+    "version": "1.1.0-alpha.1",
     "description": "",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/markdown-it/src/index.ts
+++ b/packages/markdown-it/src/index.ts
@@ -9,14 +9,14 @@ export default function markdownIt(
         if (filetypes.every((filetype) => !filePath.endsWith(`.${filetype}`))) {
             return file;
         }
-        return `
+        return Buffer.from(`
         <!DOCTYPE html>
         <html>
             <body>
-                ${markdownIt.render(file)}
+                ${markdownIt.render(file.toString())}
             </body>
         </html>
-        `;
+        `);
     };
     return plugin;
 }

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@previewed/plugin-text",
-    "version": "1.0.0",
+    "version": "1.1.0-alpha.1",
     "description": "",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/text/src/index.ts
+++ b/packages/text/src/index.ts
@@ -5,11 +5,12 @@ export default function text({ filetypes = ['txt'] } = {}) {
         for (const filetype of filetypes) {
             if (!filePath.endsWith(`.${filetype}`)) return file;
         }
-        return `
+        return Buffer.from(`
         <!DOCTYPE html>
         <html>
             <body>
                 ${file
+                    .toString()
                     .replaceAll('&', '&amp;')
                     .replaceAll('<', '&lt;')
                     .replaceAll('>', '&gt;')
@@ -17,7 +18,7 @@ export default function text({ filetypes = ['txt'] } = {}) {
                     .replaceAll(' ', '&nbsp;')}
             </body>
         </html>
-        `;
+        `);
     };
     return plugin;
 }

--- a/packages/watch/package.json
+++ b/packages/watch/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@previewed/plugin-watch",
-    "version": "1.0.0",
+    "version": "1.1.0-alpha.1",
     "description": "",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/watch/src/index.ts
+++ b/packages/watch/src/index.ts
@@ -31,7 +31,7 @@ export default function watch({
         const script = dom.window.document.createElement('script');
         script.innerHTML = `new WebSocket('ws://${host}:${port}').addEventListener('message', () => location.reload())`;
         dom.window.document.body.appendChild(script);
-        return dom.serialize();
+        return Buffer.from(dom.serialize());
     };
     return plugin;
 }


### PR DESCRIPTION
Old plugin api used strings, which didn't work so well with with images and such, so:

```ts
type Plugin = (file: string, filePath: string) => string
```
turned into:
```ts
type Plugin = (file: Buffer, filePath: string) => Buffer
```