### PR TITLE
Converted plugin API to use buffers instead of strings

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,7 +31,7 @@ export default function init({
             const processedFiles = plugins.reduce((file, plugin) => {
                 return plugin(file, filePath, { host, port, dir });
             }, file);
-            res.setHeader('Content-Disposition', 'inline');
+            res.set('Content-Type', 'text/html');
             res.send(processedFiles);
         } catch {
             res.send(`No file at path ${req.url}`);

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -6,7 +6,7 @@ export default function css(css: string, { filetypes = ['html'] } = {}) {
         if (filetypes.every((filetype) => !filePath.endsWith(`.${filetype}`))) {
             return file;
         }
-        const jsdom = new JSDOM(file);
+        const jsdom = new JSDOM(file.toString());
         const style = jsdom.window.document.createElement('style');
         style.innerHTML = css;
         jsdom.window.document.head.appendChild(style);

--- a/packages/watch/src/index.ts
+++ b/packages/watch/src/index.ts
@@ -27,7 +27,7 @@ export default function watch({
             return file;
         }
         dirs.add(options.dir);
-        const dom = new JSDOM(file);
+        const dom = new JSDOM(file.toString());
         const script = dom.window.document.createElement('script');
         script.innerHTML = `new WebSocket('ws://${host}:${port}').addEventListener('message', () => location.reload())`;
         dom.window.document.body.appendChild(script);


### PR DESCRIPTION
Previously only supported plane text files, now supports any file.

BREAKING_CHANGES: Now plugins use buffers instead of text.